### PR TITLE
Fix Google login configuration

### DIFF
--- a/compomentLogin/SocialButtons.jsx
+++ b/compomentLogin/SocialButtons.jsx
@@ -30,7 +30,14 @@ const redirectUri = AuthSession.makeRedirectUri({ useProxy: true });
 const SocialButtons = () => {
   const router = useRouter();
   const [request, response, promptAsync] = Google.useIdTokenAuthRequest({
-    clientId: '625212493169-ptarfq8gddcsl2q9a6mf0ev7560et1d0.apps.googleusercontent.com',
+    expoClientId:
+      '625212493169-ptarfq8gddcsl2q9a6mf0ev7560et1d0.apps.googleusercontent.com',
+    androidClientId:
+      '625212493169-ptarfq8gddcsl2q9a6mf0ev7560et1d0.apps.googleusercontent.com',
+    iosClientId:
+      '625212493169-ptarfq8gddcsl2q9a6mf0ev7560et1d0.apps.googleusercontent.com',
+    webClientId:
+      '625212493169-ptarfq8gddcsl2q9a6mf0ev7560et1d0.apps.googleusercontent.com',
     redirectUri,
   });
 


### PR DESCRIPTION
## Summary
- update Google login initialization to use platform-specific client IDs

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_b_6865d96d31848331bdf6d929fced2ecc

## Summary by Sourcery

Bug Fixes:
- Use platform-specific client IDs (expo, android, iOS, web) in Google login request instead of a generic clientId