### PR TITLE
Fix Google login error handling

### DIFF
--- a/compomentLogin/SocialButtons.jsx
+++ b/compomentLogin/SocialButtons.jsx
@@ -13,6 +13,7 @@ import * as Google from 'expo-auth-session/providers/google';
 import * as AuthSession from 'expo-auth-session'; 
 import { GoogleAuthProvider, signInWithCredential } from 'firebase/auth';
 import { auth } from '../utils/firebase';
+import Toast from 'react-native-toast-message';
 import axiosInstance from '../utils/AxiosInstance';
 import { useRouter } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -68,10 +69,30 @@ const SocialButtons = () => {
             }
           } catch (e) {
             console.log('Error saving user to API:', e);
+            Toast.show({
+              type: 'error',
+              text1: 'Lỗi đăng nhập',
+              text2: 'Không thể lưu thông tin người dùng',
+              position: 'top',
+            });
           }
           router.replace('/HomeScreen');
         })
-        .catch((err) => console.log(err));
+        .catch((err) => {
+          console.log(err);
+          Toast.show({
+            type: 'error',
+            text1: 'Đăng nhập Google thất bại',
+            text2: err.message || 'Vui lòng thử lại',
+            position: 'top',
+          });
+        });
+    } else if (response?.type === 'error') {
+      Toast.show({
+        type: 'error',
+        text1: 'Đăng nhập Google thất bại',
+        position: 'top',
+      });
     }
   }, [response]);
 

--- a/utils/firebase.js
+++ b/utils/firebase.js
@@ -1,20 +1,21 @@
 // Import the functions you need from the SDKs you need
-import { initializeApp } from "firebase/app";
-// TODO: Add SDKs for Firebase products that you want to use
-// https://firebase.google.com/docs/web/setup#available-libraries
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
 
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
-  apiKey: "AIzaSyB6S5pYaW3ARIAKIof3HdTgFFLjUsp_X6I",
-  authDomain: "banlaptop-b34ac.firebaseapp.com",
-  databaseURL: "https://banlaptop-b34ac-default-rtdb.asia-southeast1.firebasedatabase.app",
-  projectId: "banlaptop-b34ac",
-  storageBucket: "banlaptop-b34ac.firebasestorage.app",
-  messagingSenderId: "625212493169",
-  appId: "1:625212493169:web:73d9d7ee0e3b47d15dfad0",
-  measurementId: "G-2J8T6MF5DG"
+  apiKey: 'AIzaSyB6S5pYaW3ARIAKIof3HdTgFFLjUsp_X6I',
+  authDomain: 'banlaptop-b34ac.firebaseapp.com',
+  databaseURL: 'https://banlaptop-b34ac-default-rtdb.asia-southeast1.firebasedatabase.app',
+  projectId: 'banlaptop-b34ac',
+  storageBucket: 'banlaptop-b34ac.firebasestorage.app',
+  messagingSenderId: '625212493169',
+  appId: '1:625212493169:web:73d9d7ee0e3b47d15dfad0',
+  measurementId: 'G-2J8T6MF5DG',
 };
 
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
+// Initialize Firebaseconst app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+
+export default app;


### PR DESCRIPTION
## Summary
- export the Firebase auth instance
- show user-facing toasts when Google login fails

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_b_686df78672248331b6d81d3fb2251388