### PR TITLE
Move order status view to detail screen

### DIFF
--- a/app/CheckoutSuccess.jsx
+++ b/app/CheckoutSuccess.jsx
@@ -242,7 +242,7 @@ export default function CheckoutSuccess() {
       
               <TouchableOpacity
           style={styles.primaryBtn}
-          onPress={() => router.push("/theodoidonhang")}
+          onPress={() => router.push("/donhang")}
           activeOpacity={0.85}
         >
           <View style={styles.primaryBtnBlue}>

--- a/app/Profile.jsx
+++ b/app/Profile.jsx
@@ -186,7 +186,7 @@ export default function Profile() {
               {
                 icon: <Feather name="package" size={22} color="#1976ff" />,
                 label: "Theo dõi đơn hàng",
-                onPress: () => router.push("./theodoidonhang"),
+                onPress: () => router.push("./donhang"),
               },
               
               {

--- a/app/chitietdonhang.jsx
+++ b/app/chitietdonhang.jsx
@@ -1,0 +1,297 @@
+import { Feather } from '@expo/vector-icons';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import React, { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  FlatList,
+  Image,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import OrderStatusStepper from '../components/OrderStatusStepper';
+import axiosInstance from '../utils/AxiosInstance';
+
+function formatCurrency(num) {
+  return typeof num === 'number' ? num.toLocaleString('vi-VN') + ' đ' : '';
+}
+
+export default function OrderDetailScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams();
+  const orderId = params.orderId || params.id;
+
+  const [order, setOrder] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let ignore = false;
+    if (!orderId) return;
+    setLoading(true);
+    axiosInstance
+      .get(`/orders/${orderId}`)
+      .then((res) => {
+        if (!ignore) setOrder(res.data);
+      })
+      .catch((err) => {
+        console.error('Fetch order detail error:', err);
+      })
+      .finally(() => {
+        if (!ignore) setLoading(false);
+      });
+    return () => {
+      ignore = true;
+    };
+  }, [orderId]);
+
+  const renderProduct = ({ item }) => (
+    <View style={styles.productRow}>
+      <Image
+        source={
+          item.productId?.image
+            ? { uri: item.productId.image }
+            : item.productId?.images?.length > 0
+            ? { uri: item.productId.images[0] }
+            : require('../assets/images/pc1.png')
+        }
+        style={styles.productImg}
+      />
+      <View style={styles.productInfo}>
+        <Text numberOfLines={2} style={styles.productName}>
+          {item.productId?.name || 'Sản phẩm'}
+        </Text>
+        <Text style={styles.productPrice}>
+          {formatCurrency(item.productId?.price ?? 0)}
+        </Text>
+      </View>
+      <Text style={styles.productQty}>x{item.quantity}</Text>
+    </View>
+  );
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color="#6366F1" />
+      </View>
+    );
+  }
+
+  if (!order) {
+    return (
+      <View style={styles.center}>
+        <Text>Không tìm thấy đơn hàng</Text>
+      </View>
+    );
+  }
+
+  const orderDate = order.order_date
+    ? new Date(order.order_date).toLocaleString('vi-VN', {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : '';
+
+  return (
+    <View style={{ flex: 1, backgroundColor: '#F9FAFB' }}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.headerBtn}>
+          <Feather name="arrow-left" size={24} color="#1F2937" />
+        </TouchableOpacity>
+        <Text style={styles.headerTitle}>Chi tiết đơn hàng</Text>
+        <View style={styles.headerBtn} />
+      </View>
+
+      <ScrollView contentContainerStyle={styles.container}>
+        <OrderStatusStepper
+          orderId={order._id}
+          initialStatus={order.status}
+          onStatusChange={(status) =>
+            setOrder((prev) => ({ ...prev, status }))
+          }
+        />
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Thông tin đơn hàng</Text>
+          <View style={styles.row}>
+            <Text style={styles.label}>Mã đơn hàng</Text>
+            <Text style={styles.value}>{order._id}</Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>Ngày đặt</Text>
+            <Text style={styles.value}>{orderDate}</Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>Phương thức thanh toán</Text>
+            <Text style={styles.value}>{order.paymentMethod || '--'}</Text>
+          </View>
+          <View style={styles.row}>
+            <Text style={styles.label}>Phí vận chuyển</Text>
+            <Text style={styles.value}>
+              {formatCurrency(order.shippingFee || 0)}
+            </Text>
+          </View>
+          {order.discount > 0 && (
+            <View style={styles.row}>
+              <Text style={styles.label}>Giảm giá</Text>
+              <Text style={styles.value}>
+                -{formatCurrency(order.discount)}
+              </Text>
+            </View>
+          )}
+          <View style={[styles.row, styles.totalRow]}>
+            <Text style={styles.totalLabel}>Tổng cộng</Text>
+            <Text style={styles.total}>{formatCurrency(order.total)}</Text>
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Địa chỉ giao hàng</Text>
+          <Text style={styles.addressText}>
+            {order.shippingAddress?.recipientName}
+          </Text>
+          <Text style={styles.addressText}>
+            {order.shippingAddress?.phoneNumber}
+          </Text>
+          <Text style={styles.addressText}>
+            {order.shippingAddress?.address}
+          </Text>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Sản phẩm</Text>
+          <FlatList
+            data={order.products || []}
+            keyExtractor={(item) => item._id}
+            renderItem={renderProduct}
+            scrollEnabled={false}
+            contentContainerStyle={{ paddingVertical: 4 }}
+          />
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 12,
+    backgroundColor: '#FFFFFF',
+    borderBottomWidth: 1,
+    borderBottomColor: '#E5E7EB',
+  },
+  headerBtn: {
+    width: 24,
+    height: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#1F2937',
+  },
+  container: {
+    padding: 16,
+    paddingBottom: 40,
+  },
+  center: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  section: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: '#000',
+    shadowOpacity: 0.05,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 12,
+    color: '#374151',
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 8,
+  },
+  label: {
+    fontSize: 14,
+    color: '#6B7280',
+    flex: 1,
+  },
+  value: {
+    fontSize: 14,
+    color: '#111827',
+    flex: 1,
+    textAlign: 'right',
+  },
+  totalRow: {
+    borderTopWidth: 1,
+    borderTopColor: '#E5E7EB',
+    paddingTop: 8,
+    marginTop: 8,
+  },
+  totalLabel: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#111827',
+  },
+  total: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#DC2626',
+  },
+  addressText: {
+    fontSize: 14,
+    color: '#374151',
+    marginBottom: 4,
+  },
+  productRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginVertical: 8,
+  },
+  productImg: {
+    width: 56,
+    height: 56,
+    borderRadius: 12,
+    backgroundColor: '#F3F4F6',
+  },
+  productInfo: {
+    flex: 1,
+    marginLeft: 12,
+  },
+  productName: {
+    fontSize: 14,
+    fontWeight: '500',
+    color: '#374151',
+    marginBottom: 4,
+  },
+  productPrice: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#DC2626',
+  },
+  productQty: {
+    fontSize: 14,
+    color: '#6B7280',
+    marginLeft: 8,
+  },
+});

--- a/app/donhang.jsx
+++ b/app/donhang.jsx
@@ -19,7 +19,6 @@ import {
   StatusBar
 } from 'react-native';
 import { TabBar, TabView } from 'react-native-tab-view';
-import OrderStatusStepper from '../components/OrderStatusStepper';
 import axiosInstance from '../utils/AxiosInstance';
 
 const TAB_CONFIG = {
@@ -38,6 +37,7 @@ function formatCurrency(num) {
 }
 
 const OrderCard = React.memo(({ order, tab, onCancel, onStatusChange, onReview }) => {
+  const router = useRouter();
   const itemCount = order.products?.reduce((sum, p) => sum + p.quantity, 0) || 0;
 
   const getStatusColor = (status) => {
@@ -56,7 +56,9 @@ const OrderCard = React.memo(({ order, tab, onCancel, onStatusChange, onReview }
   const statusColor = getStatusColor(order.status);
 
   return (
-    <View style={styles.card}>
+    <TouchableOpacity style={styles.card} activeOpacity={0.8}
+      onPress={() => router.push({ pathname: '/chitietdonhang', params: { orderId: order._id } })}
+    >
       {/* Gradient Header */}
       <View style={styles.cardHeader}>
         <View style={styles.shopSection}>
@@ -133,14 +135,6 @@ const OrderCard = React.memo(({ order, tab, onCancel, onStatusChange, onReview }
         </View>
       </View>
 
-      {/* Order Status Stepper */}
-      <View style={styles.stepperContainer}>
-        <OrderStatusStepper
-          orderId={order._id}
-          initialStatus={order.status}
-          onStatusChange={onStatusChange}
-        />
-      </View>
 
       {/* Review Buttons */}
       {order.status === 'delivered' && order.products?.filter(p => p.productId).length > 0 && (
@@ -160,7 +154,7 @@ const OrderCard = React.memo(({ order, tab, onCancel, onStatusChange, onReview }
           ))}
         </View>
       )}
-    </View>
+    </TouchableOpacity>
   );
 });
 
@@ -717,13 +711,6 @@ const styles = StyleSheet.create({
     fontWeight: '700', 
     color: '#DC2626',
   },
-
-  // Stepper Container
-  stepperContainer: {
-    paddingHorizontal: 16,
-    paddingTop: 12,
-  },
-
   // Review Section
   reviewSection: {
     paddingHorizontal: 16,

--- a/compomentPay/PayStatusModal.jsx
+++ b/compomentPay/PayStatusModal.jsx
@@ -61,7 +61,7 @@ export default function PayStatusModal({ payStatus, setPayStatus, router }) {
                 style={[styles.statusBtn, { backgroundColor: "#eaf3ff", marginTop: 18 }]}
                 onPress={() => {
                   setPayStatus(null);
-                  router.push("./theodoidonhang");
+                  router.push("./donhang");
                 }}
               >
                 <Text style={[styles.statusBtnText, { color: "#2979ff" }]}>


### PR DESCRIPTION
## Summary
- rename `theodoidonhang.jsx` to `donhang.jsx`
- remove OrderStatusStepper from order list
- navigate to order detail on card press
- update references to new route

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_b_687f94da03dc832cbfcaa77a613604a8

## Summary by Sourcery

Introduce a dedicated order detail screen with status stepper and migrate navigation from the order list to this new view, renaming the previous order list component and updating all related routes.

New Features:
- Add OrderDetailScreen at /chitietdonhang to display complete order details and include the OrderStatusStepper.
- Enable tapping on an order card in the list to navigate to the detail screen with the orderId parameter.

Enhancements:
- Rename the order list component and route from theodoidonhang to donhang.
- Remove the status stepper from the order list view.
- Update navigation paths in CheckoutSuccess, Profile, and PayStatusModal to use the new donhang route.