### PR TITLE
Add simple dark mode toggle

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,6 +2,7 @@
 import { Stack } from "expo-router";
 import Toast from "react-native-toast-message";
 import { WishlistProvider } from "../context/WishlistContext";
+import { ThemeProvider, useTheme } from "../context/ThemeContext";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 import { useEffect } from "react";
 import {
@@ -19,25 +20,34 @@ export default function RootLayout() {
     FontAwesome.loadFont();
     AntDesign.loadFont();
   }, []);
+
   return (
-    <WishlistProvider>
-      <SafeAreaProvider>
-        {/* SafeAreaView sẽ tự động padding bên trên để khỏi bị che */}
-        <SafeAreaView style={{ flex: 1 }}>
-          <StripeProvider
-            publishableKey="pk_test_51RgeVG4drE7VMTu3y19cSIlHqr0RqAlwpr0IsCm5dgw6wKyWbPRAL1JdyHvq1kKOX1zn1Pcx3ja16OoYERv2pxWT00ZODfs9px"
-            merchantIdentifier="merchant.com.yourapp"
-          >
-            <Stack
-              screenOptions={{
-                headerShown: false, // tắt hết header mặc định
-              }}
-            />
-          </StripeProvider>
-          <Toast />
-        </SafeAreaView>
-      </SafeAreaProvider>
-    </WishlistProvider>
+    <ThemeProvider>
+      <WishlistProvider>
+        <SafeAreaProvider>
+          <ThemedRoot />
+        </SafeAreaProvider>
+      </WishlistProvider>
+    </ThemeProvider>
+  );
+}
+
+function ThemedRoot() {
+  const { theme } = useTheme();
+  return (
+    <SafeAreaView style={{ flex: 1, backgroundColor: theme === 'dark' ? '#000' : '#fff' }}>
+      <StripeProvider
+        publishableKey="pk_test_51RgeVG4drE7VMTu3y19cSIlHqr0RqAlwpr0IsCm5dgw6wKyWbPRAL1JdyHvq1kKOX1zn1Pcx3ja16OoYERv2pxWT00ZODfs9px"
+        merchantIdentifier="merchant.com.yourapp"
+      >
+        <Stack
+          screenOptions={{
+            headerShown: false, // tắt hết header mặc định
+          }}
+        />
+      </StripeProvider>
+      <Toast />
+    </SafeAreaView>
   );
 }
 

--- a/app/settings.jsx
+++ b/app/settings.jsx
@@ -1,0 +1,66 @@
+import { Feather } from '@expo/vector-icons';
+import { useRouter } from 'expo-router';
+import React from 'react';
+import { View, Text, StyleSheet, Switch, TouchableOpacity } from 'react-native';
+import { useTheme } from '../context/ThemeContext';
+
+export default function Settings() {
+  const router = useRouter();
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <View style={[styles.container, theme === 'dark' && styles.containerDark]}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => router.back()} style={styles.backBtn}>
+          <Feather
+            name="arrow-left"
+            size={24}
+            color={theme === 'dark' ? '#fff' : '#000'}
+          />
+        </TouchableOpacity>
+        <Text style={[styles.headerTitle, theme === 'dark' && { color: '#fff' }]}>Cài đặt</Text>
+        <View style={{ width: 24 }} />
+      </View>
+
+      <View style={styles.row}>
+        <Text style={[styles.label, theme === 'dark' && { color: '#fff' }]}>Dark mode</Text>
+        <Switch value={theme === 'dark'} onValueChange={toggleTheme} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    padding: 20,
+  },
+  containerDark: {
+    backgroundColor: '#000',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 20,
+  },
+  backBtn: {
+    padding: 4,
+  },
+  headerTitle: {
+    flex: 1,
+    textAlign: 'center',
+    fontSize: 20,
+    fontWeight: 'bold',
+  },
+  row: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: 12,
+  },
+  label: {
+    fontSize: 16,
+    color: '#000',
+  },
+});

--- a/context/ThemeContext.jsx
+++ b/context/ThemeContext.jsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+const ThemeContext = createContext();
+
+export const useTheme = () => useContext(ThemeContext);
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState("light");
+
+  useEffect(() => {
+    AsyncStorage.getItem("appTheme").then((value) => {
+      if (value === "dark" || value === "light") {
+        setTheme(value);
+      }
+    });
+  }, []);
+
+  const toggleTheme = async () => {
+    const newTheme = theme === "light" ? "dark" : "light";
+    setTheme(newTheme);
+    await AsyncStorage.setItem("appTheme", newTheme);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `ThemeProvider` for global light/dark mode
- wrap application with the provider and apply background color in `_layout.tsx`
- add `settings.jsx` screen with a switch to toggle dark mode

## Testing
- `npm run lint` *(fails: "lint" is not an expo command)*
- `npx expo lint` *(fails: "lint" is not an expo command)*

------
https://chatgpt.com/codex/tasks/task_b_687fa24a7f64832cbdf86edc61f434e5

## Summary by Sourcery

Add global dark mode support with a ThemeProvider, persistent theme storage, and a new Settings screen for toggling between light and dark modes.

New Features:
- Implement ThemeProvider with AsyncStorage persistence for light/dark theme state
- Wrap the root layout in ThemeProvider and apply background colors based on the current theme
- Add a Settings screen featuring a switch to toggle dark mode