### PR TITLE
Fix cart screen add-from-CTSP and variant picker

### DIFF
--- a/app/ctsp.jsx
+++ b/app/ctsp.jsx
@@ -182,7 +182,7 @@ export default function CTSP() {
   };
 
   // Hàm thêm vào giỏ hàng đúng như bạn yêu cầu
-  const AddToCart = async prod => {
+  const AddToCart = async (prod, variant) => {
     try {
       const userStr = await AsyncStorage.getItem('user');
       if (!userStr) {
@@ -197,11 +197,16 @@ export default function CTSP() {
       await axiosInstance.post('/orders/add-to-cart', {
         user_id: userId,
         productId: prod.id,
-        quantity: 1
+        quantity: 1,
+        variant,
       });
 
-      Toast.show({ type: 'success', text1: 'Đã thêm vào giỏ hàng!', position: 'bottom' });
-      setTimeout(() => router.push('/cart'), 1200);
+      Toast.show({
+        type: 'success',
+        text1: 'Đã thêm vào giỏ hàng!',
+        position: 'bottom',
+      });
+      router.push('/cart');
     } catch (err) {
       console.error('add-to-cart error:', err);
       Toast.show({ type: 'error', text1: 'Thêm giỏ hàng thất bại!', position: 'top' });
@@ -325,17 +330,14 @@ export default function CTSP() {
       <View style={styles.bottomBar}>
         <TouchableOpacity
           style={styles.bottomCartBtn}
-          onPress={() => AddToCart(product)} // Sửa lại dòng này
+          onPress={() => AddToCart(product, selectedVariant)}
         >
           <Feather name="shopping-cart" size={20} color="#1a73e8" />
           <Text style={styles.bottomCartText}>Giỏ hàng</Text>
         </TouchableOpacity>
         <TouchableOpacity
           style={styles.bottomBuyBtn}
-          onPress={() => AddToCart({
-            ...product,
-            variant: selectedVariant
-          })}
+          onPress={() => AddToCart(product, selectedVariant)}
         >
           <Text style={styles.bottomBuyText}>Mua ngay</Text>
         </TouchableOpacity>

--- a/compomentCart/CartProductList.jsx
+++ b/compomentCart/CartProductList.jsx
@@ -6,7 +6,16 @@ export default function CartProductList({ cart, onRemove, onQuantity, onQuantity
   return (
     <View style={styles.cartBox}>
       {cart.map(item => {
-        const variants = Array.isArray(item.variants) ? item.variants : [];
+        let variants = [];
+        if (Array.isArray(item.variants)) {
+          variants = item.variants;
+        } else if (item.variants && typeof item.variants === 'object') {
+          // Support object form {label: [options]}
+          const key = Object.keys(item.variants)[0];
+          if (Array.isArray(item.variants[key])) {
+            variants = item.variants[key];
+          }
+        }
         return (
           <View key={item.id} style={styles.productRow}>
             <TouchableOpacity style={styles.checkbox} onPress={() => onToggleSelect(item.id)}>
@@ -116,7 +125,9 @@ const styles = StyleSheet.create({
   picker: {
     flex: 1,
     height: 36,
-    backgroundColor: '#f9f9f9',
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#ddd',
     borderRadius: 4,
   },
   qtyRow: {


### PR DESCRIPTION
## Summary
- send variant when adding to cart from product page and navigate immediately
- show option picker in cart products even when variants stored as object
- tweak picker style for clarity

## Testing
- `npm run lint` *(fails: expo command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687fc2f0476c832c8ab3411f1e2e680d

## Summary by Sourcery

Enable variant support when adding products to the cart, ensure variant options display correctly for object-form variants, and improve UX by styling the picker and navigating immediately to the cart

New Features:
- Pass selected variant to AddToCart and include it in the add-to-cart API call

Bug Fixes:
- Render variant picker for cart items when variants are stored as objects

Enhancements:
- Navigate immediately to the cart screen after adding an item (remove timeout)
- Update picker styling with white background and border for clarity