### PR TITLE
Fix cart not showing products

### DIFF
--- a/app/cart.jsx
+++ b/app/cart.jsx
@@ -66,6 +66,7 @@ export default function CartScreen() {
     });
   }, []);
 
+
   // Check login
   useEffect(() => {
     AsyncStorage.getItem("token").then((token) => {
@@ -104,13 +105,20 @@ const fetchCart = useCallback(async () => {
   try {
     // 1. Fetch and normalize the API response into an array of orders
     const { data: ordersData } = await axiosInstance.get(`/orders/user/${userId}`);
-    const orders = Array.isArray(ordersData)
-      ? ordersData
-      : (ordersData.orders && Array.isArray(ordersData.orders))
-        ? ordersData.orders
-        : (typeof ordersData === "object")
-          ? [ordersData]
-          : [];
+
+    // handle possible nested data structures
+    let orders = [];
+    if (Array.isArray(ordersData)) {
+      orders = ordersData;
+    } else if (Array.isArray(ordersData?.orders)) {
+      orders = ordersData.orders;
+    } else if (Array.isArray(ordersData?.data)) {
+      orders = ordersData.data;
+    } else if (Array.isArray(ordersData?.data?.orders)) {
+      orders = ordersData.data.orders;
+    } else if (typeof ordersData === 'object') {
+      orders = [ordersData];
+    }
 
     // 2. Pick the pending (or payment_failed) order
     const pendingOrder =
@@ -182,6 +190,13 @@ const fetchCart = useCallback(async () => {
     setLoading(false);
   }
 }, [userId]);
+
+  // whenever userId becomes available, fetch cart
+  useEffect(() => {
+    if (userId) {
+      fetchCart();
+    }
+  }, [userId, fetchCart]);
 
   // Handlers
   const handleQuantity = async (id, delta) => {


### PR DESCRIPTION
## Summary
- ensure cart fetch runs when userId loads
- normalize orders data from API with multiple shapes

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_b_687fc84528fc832cbdefeec4be6fd0a0

## Summary by Sourcery

Ensure cart data is fetched when the user ID becomes available and normalize API orders data across different response structures.

Bug Fixes:
- Trigger cart fetch when userId loads to display products in the cart

Enhancements:
- Extend orders data normalization to handle various nested API response shapes