### PR TITLE
Add PayOS payment option

### DIFF
--- a/app/pay.jsx
+++ b/app/pay.jsx
@@ -9,7 +9,9 @@ import {
   Text,
   TouchableOpacity,
   View,
+  Platform,
 } from "react-native";
+import { WebView } from "react-native-webview";
 import Toast from "react-native-toast-message";
 import axiosInstance from "../utils/AxiosInstance";
 import VnPayModal from "../compomentPay/Vnpaymodal";
@@ -53,6 +55,8 @@ export default function PayScreen() {
   const [showCardModal, setShowCardModal] = useState(false);
   const [selectedCard, setSelectedCard] = useState(null);
   const [showStripe, setShowStripe] = useState(false);
+  const [showPayOS, setShowPayOS] = useState(false);
+  const [payOSUrl, setPayOSUrl] = useState(null);
 
   const [provinces, setProvinces] = useState([]);
   const [districts, setDistricts] = useState([]);
@@ -509,6 +513,21 @@ export default function PayScreen() {
         setShowStripe(true);
         return;
       }
+      if (selectedPayment === "bank") {
+        try {
+          const payRes = await axiosInstance.post("/payos/checkout", {
+            orderId: res.data.orderId,
+            amount: total,
+          });
+          if (payRes.data.url) {
+            setPayOSUrl(payRes.data.url);
+            setShowPayOS(true);
+            return;
+          }
+        } catch (err) {
+          Toast.show({ type: "error", text1: "Thanh toán PayOS thất bại" });
+        }
+      }
 
       Toast.show({
         type: "success",
@@ -586,7 +605,8 @@ export default function PayScreen() {
   };
 
   return (
-    <ScrollView style={styles.container}>
+    <View style={{ flex: 1 }}>
+      <ScrollView style={styles.container}>
       {/* Address Selection */}
       <View style={styles.section}>
         <Text style={styles.sectionTitle}>Địa chỉ giao hàng</Text>
@@ -711,78 +731,101 @@ export default function PayScreen() {
       <TouchableOpacity style={styles.orderButton} onPress={handleOrder}>
         <Text style={styles.orderButtonText}>Đặt hàng</Text>
       </TouchableOpacity>
-
-      {/* Modals */}
-      <AddressModal
-        visible={showAddressModal}
-        onClose={() => setShowAddressModal(false)}
-        addressList={addressList}
-        selectedAddress={selectedAddress}
-        onSelectAddress={handleAddressSelect}
-        onAddressAdded={handleAddressAdded}
-        provinces={provinces}
-        districts={districts}
-        wards={wards}
-        selectedProvince={selectedProvince}
-        selectedDistrict={selectedDistrict}
-        selectedWard={selectedWard}
-        setSelectedProvince={setSelectedProvince}
-        setSelectedDistrict={setSelectedDistrict}
-        setSelectedWard={setSelectedWard}
-      />
-
-      <PayCardModal
-        visible={showCardModal}
-        onClose={() => setShowCardModal(false)}
-        selectedCard={selectedCard}
-        onSelectCard={setSelectedCard}
-      />
-
-      <VnPayModal
-        visible={showVnPayModal}
-        orderId={vnpayData?.orderId}
-        amount={vnpayData?.amount}
-        orderInfo={vnpayData?.orderInfo}
-        onClose={handleVnPayClose}
-      />
-
-      <StripeModal
-        visible={showStripe}
-        amount={orderAmount}
-        orderId={orderId}
-        onClose={(result) => {
-          setShowStripe(false);
-          if (result?.success) {
-            Toast.show({
-              type: "success",
-              text1: "Thanh toán thành công!",
-            });
-            router.push({
-              pathname: "/CheckoutSuccess",
-              params: {
-                orderId,
-                total: orderAmount,
-                products: JSON.stringify(products),
-                address: selectedAddress?.address || addressText,
-                paymentMethod: "stripe",
-              },
-            });
-          } else if (result?.message) {
-            Toast.show({
-              type: "error",
-              text1: "Thanh toán thất bại!",
-              text2: result.message,
-            });
-          }
-        }}
-      />
-
-      <PayStatusModal
-        visible={payStatus !== null}
-        status={payStatus}
-        onClose={() => setPayStatus(null)}
-      />
     </ScrollView>
+
+    {/* Modals */}
+    <AddressModal
+      visible={showAddressModal}
+      onClose={() => setShowAddressModal(false)}
+      addressList={addressList}
+      selectedAddress={selectedAddress}
+      onSelectAddress={handleAddressSelect}
+      onAddressAdded={handleAddressAdded}
+      provinces={provinces}
+      districts={districts}
+      wards={wards}
+      selectedProvince={selectedProvince}
+      selectedDistrict={selectedDistrict}
+      selectedWard={selectedWard}
+      setSelectedProvince={setSelectedProvince}
+      setSelectedDistrict={setSelectedDistrict}
+      setSelectedWard={setSelectedWard}
+    />
+
+    <PayCardModal
+      visible={showCardModal}
+      onClose={() => setShowCardModal(false)}
+      selectedCard={selectedCard}
+      onSelectCard={setSelectedCard}
+    />
+
+    <VnPayModal
+      visible={showVnPayModal}
+      orderId={vnpayData?.orderId}
+      amount={vnpayData?.amount}
+      orderInfo={vnpayData?.orderInfo}
+      onClose={handleVnPayClose}
+    />
+
+    <StripeModal
+      visible={showStripe}
+      amount={orderAmount}
+      orderId={orderId}
+      onClose={(result) => {
+        setShowStripe(false);
+        if (result?.success) {
+          Toast.show({
+            type: "success",
+            text1: "Thanh toán thành công!",
+          });
+          router.push({
+            pathname: "/CheckoutSuccess",
+            params: {
+              orderId,
+              total: orderAmount,
+              products: JSON.stringify(products),
+              address: selectedAddress?.address || addressText,
+              paymentMethod: "stripe",
+            },
+          });
+        } else if (result?.message) {
+          Toast.show({
+            type: "error",
+            text1: "Thanh toán thất bại!",
+            text2: result.message,
+          });
+        }
+      }}
+    />
+
+    {/* PayOS WebView */}
+    {showPayOS && payOSUrl && (
+      <View style={{ flex: 1 }}>
+        <TouchableOpacity
+          style={styles.closeBtn}
+          onPress={() => setShowPayOS(false)}
+        >
+          <Feather name="x" size={24} color="#000" />
+        </TouchableOpacity>
+        <WebView
+          source={{ uri: payOSUrl }}
+          style={{ flex: 1 }}
+          onNavigationStateChange={(navState) => {
+            if (navState.url.includes("/success")) {
+              setShowPayOS(false);
+              setPayStatus("success");
+            }
+          }}
+        />
+      </View>
+    )}
+
+    <PayStatusModal
+      visible={payStatus !== null}
+      status={payStatus}
+      onClose={() => setPayStatus(null)}
+    />
+  </View>
   );
 }
 
@@ -932,6 +975,13 @@ const styles = StyleSheet.create({
     color: "#fff",
     fontSize: 18,
     fontWeight: "bold",
+  },
+  closeBtn: {
+    position: "absolute",
+    top: Platform.OS === "ios" ? 50 : 20,
+    right: 16,
+    zIndex: 1,
+    padding: 8,
   },
   // PayScreen styles
   voucherContainer: {


### PR DESCRIPTION
## Summary
- integrate PayOS checkout via WebView on pay screen
- overlay PayOS webview and handle success callback
- add close button styling for PayOS view

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_b_688257980a84832c84a191298aeccd42

## Summary by Sourcery

Integrate a new PayOS payment option into the PayScreen by fetching the checkout URL, presenting it in a WebView overlay with a close button, and handling payment success callbacks.

New Features:
- Add PayOS payment method on checkout that initiates backend /payos/checkout and opens the returned URL in a WebView overlay
- Overlay PayOS WebView on the pay screen with a styled close button
- Detect PayOS success callback in the WebView and display the payment status modal

Enhancements:
- Restructure PayScreen layout by wrapping the ScrollView and modals in a parent View to support full-screen overlays