### PR TITLE
Add VietQR payment screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,6 @@ Trang `app/VietQRScreen.jsx` cho phép hiển thị QR Code động dùng dịch
 ```
 
 Ứng dụng sẽ hiển thị hình ảnh QR Code để người dùng quét bằng ứng dụng ngân hàng.
+Khi thanh toán thành công, backend sẽ phát sự kiện `payment_success` qua Socket.IO.
+Trang `VietQRScreen` lắng nghe sự kiện này và hiển thị hộp thoại thông báo.
+Nhấn **OK** trong hộp thoại sẽ chuyển đến trang `CheckoutSuccess`.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ This repository contains a React Native application built with [Expo](https://ex
    ```
 
 Use the Expo CLI prompts to run the app on a simulator or physical device (e.g. with `--android`, `--ios` or web). For more details, see the [Expo documentation](https://docs.expo.dev/).
+
+## Thanh toán qua VietQR
+
+Trang `app/VietQRScreen.jsx` cho phép hiển thị QR Code động dùng dịch vụ [SePay](https://qr.sepay.vn). Truyền các tham số `acc`, `bank`, `amount` (tuỳ chọn) và `des` (tuỳ chọn) qua query trên đường dẫn để tạo mã QR. Ví dụ:
+
+```
+/VietQRScreen?acc=0010000000355&bank=Vietcombank&amount=100000&des=Ung%20ho
+```
+
+Ứng dụng sẽ hiển thị hình ảnh QR Code để người dùng quét bằng ứng dụng ngân hàng.

--- a/app/VietQRScreen.jsx
+++ b/app/VietQRScreen.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { View, Text, Image, StyleSheet } from 'react-native';
+import { useLocalSearchParams } from 'expo-router';
+
+export default function VietQRScreen() {
+  const { acc, bank, amount, des } = useLocalSearchParams();
+
+  if (!acc || !bank) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.error}>Thiếu tham số tài khoản hoặc ngân hàng</Text>
+      </View>
+    );
+  }
+
+  const query = [
+    `acc=${encodeURIComponent(acc)}`,
+    `bank=${encodeURIComponent(bank)}`,
+  ];
+  if (amount) query.push(`amount=${encodeURIComponent(amount)}`);
+  if (des) query.push(`des=${encodeURIComponent(des)}`);
+
+  const qrUrl = `https://qr.sepay.vn/img?${query.join('&')}`;
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Quét mã để thanh toán</Text>
+      <Image source={{ uri: qrUrl }} style={styles.qrImage} />
+      {amount ? (
+        <Text style={styles.text}>Số tiền: {amount}</Text>
+      ) : null}
+      {des ? (
+        <Text style={styles.text}>Nội dung: {decodeURIComponent(des)}</Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 20,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 20,
+  },
+  qrImage: {
+    width: 260,
+    height: 260,
+    marginBottom: 20,
+  },
+  text: {
+    fontSize: 16,
+    marginBottom: 8,
+  },
+  error: {
+    fontSize: 16,
+    color: 'red',
+  },
+});

--- a/app/VietQRScreen.jsx
+++ b/app/VietQRScreen.jsx
@@ -1,9 +1,48 @@
-import React from 'react';
-import { View, Text, Image, StyleSheet } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
+import React, { useEffect } from 'react';
+import { View, Text, Image, StyleSheet, Alert } from 'react-native';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { io } from 'socket.io-client';
+import axiosInstance from '../utils/AxiosInstance';
 
 export default function VietQRScreen() {
-  const { acc, bank, amount, des } = useLocalSearchParams();
+  const router = useRouter();
+  const {
+    acc,
+    bank,
+    amount,
+    des,
+    orderId,
+    total,
+    products,
+    address,
+    paymentMethod,
+  } = useLocalSearchParams();
+
+  useEffect(() => {
+    const socket = io(axiosInstance.defaults.baseURL);
+    socket.on('payment_success', (payload) => {
+      if (
+        payload.id === Number(orderId) ||
+        String(payload.id) === String(orderId)
+      ) {
+        Alert.alert(
+          'Thanh toán thành công',
+          `Số tiền: ${payload.amount}₫\nNgân hàng: ${payload.gateway}`,
+          [
+            {
+              text: 'OK',
+              onPress: () =>
+                router.replace({
+                  pathname: '/CheckoutSuccess',
+                  params: { orderId, total, products, address, paymentMethod },
+                }),
+            },
+          ],
+        );
+      }
+    });
+    return () => socket.disconnect();
+  }, [orderId]);
 
   if (!acc || !bank) {
     return (

--- a/app/pay.jsx
+++ b/app/pay.jsx
@@ -28,6 +28,10 @@ const SHOP_DISTRICT_ID = 1461;
 const SHOP_WARD_CODE = "21308";
 const GHN_BASE_URL = "https://dev-online-gateway.ghn.vn/shiip/public-api";
 
+// VietQR config
+const VIETQR_ACCOUNT = "0010000000355";
+const VIETQR_BANK = "Vietcombank";
+
 const paymentMethods = [
   { key: "cod", label: "Thanh toán khi nhận hàng" },
   { key: "bank", label: "Thanh toán bằng thẻ ngân hàng" },
@@ -514,19 +518,16 @@ export default function PayScreen() {
         return;
       }
       if (selectedPayment === "bank") {
-        try {
-          const payRes = await axiosInstance.post("/payos/checkout", {
-            orderId: res.data.orderId,
-            amount: total,
-          });
-          if (payRes.data.url) {
-            setPayOSUrl(payRes.data.url);
-            setShowPayOS(true);
-            return;
-          }
-        } catch (err) {
-          Toast.show({ type: "error", text1: "Thanh toán PayOS thất bại" });
-        }
+        router.push({
+          pathname: "/VietQRScreen",
+          params: {
+            acc: VIETQR_ACCOUNT,
+            bank: VIETQR_BANK,
+            amount: total.toString(),
+            des: `Thanh toan don hang ${res.data.orderId}`,
+          },
+        });
+        return;
       }
 
       Toast.show({

--- a/app/pay.jsx
+++ b/app/pay.jsx
@@ -525,6 +525,11 @@ export default function PayScreen() {
             bank: VIETQR_BANK,
             amount: total.toString(),
             des: `Thanh toan don hang ${res.data.orderId}`,
+            orderId: res.data.orderId,
+            total,
+            products: JSON.stringify(products),
+            address: selectedAddress?.address || addressText,
+            paymentMethod: selectedPayment,
           },
         });
         return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,8 @@
         "react-native-toast-message": "^2.3.0",
         "react-native-vector-icons": "^10.2.0",
         "react-native-web": "~0.20.0",
-        "react-native-webview": "13.13.5"
+        "react-native-webview": "13.13.5",
+        "socket.io-client": "^4.8.1"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -4138,6 +4139,12 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@stripe/react-stripe-js": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-3.7.0.tgz",
@@ -6899,6 +6906,66 @@
       "dev": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/entities": {
@@ -13932,6 +13999,68 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -15470,6 +15599,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "react-native-toast-message": "^2.3.0",
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "socket.io-client": "^4.8.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- add VietQRScreen page to show dynamic payment QR codes
- document how to use VietQRScreen
- send order data from pay screen to VietQR screen

## Testing
- `npx expo lint` *(fails: Cannot find module 'eslint')*

------
https://chatgpt.com/codex/tasks/task_b_688270c09234832ca78919f157a0f678

## Summary by Sourcery

Add a new VietQR payment screen and integrate it into the bank payment flow, along with updating documentation.

New Features:
- Introduce VietQRScreen component to generate and display dynamic QR codes via SePay using provided query parameters
- Modify PayScreen to navigate to VietQRScreen for bank payments, passing account, bank, amount, and description

Documentation:
- Document VietQRScreen usage and query parameters in README