### PR TITLE
Improve image caching for products

### DIFF
--- a/app/HomeScreen.jsx
+++ b/app/HomeScreen.jsx
@@ -25,6 +25,7 @@ import Header from "../compomentHome/Header";
 import NewProducts from "../compomentHome/NewProducts";
 import PromoPopup from "../compomentHome/PromoPopup";
 import axiosInstance from "../utils/AxiosInstance";
+import { cacheImages } from "../utils/cacheImages";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 
 const { width } = Dimensions.get("window");
@@ -184,13 +185,14 @@ export default function HomeScreen() {
             isHot: (p.sold || 0) > 50,
             isBestSeller: p.isBestSeller ?? false,
             price: (p.price ?? 0).toLocaleString('vi-VN') + ' đ',
-            originalPrice: p.originalPrice
-              ? p.originalPrice.toLocaleString('vi-VN') + ' đ'
-              : undefined,
-          };
+          originalPrice: p.originalPrice
+            ? p.originalPrice.toLocaleString('vi-VN') + ' đ'
+            : undefined,
+        };
         });
 
         setProducts(mapped);
+        cacheImages(mapped.map((p) => p.image?.uri || p.image));
         setBestSellers(mapped.filter(p => p.isBestSeller));
         // Lọc flash sale: chỉ những sản phẩm có discount > 0
         setFlashSaleProducts(mapped.filter(p => p.discount > 0));
@@ -238,6 +240,7 @@ export default function HomeScreen() {
           });
 
           setProducts(mapped);
+          cacheImages(mapped.map((p) => p.image?.uri || p.image));
           setBestSellers(mapped.filter(p => p.isBestSeller));
           // Lọc flash sale: chỉ những sản phẩm có discount > 0
           setFlashSaleProducts(mapped.filter(p => p.discount > 0));

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -5,6 +5,7 @@ import { WishlistProvider } from "../context/WishlistContext";
 import { ThemeProvider, useTheme } from "../context/ThemeContext";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 import { useEffect } from "react";
+import { cacheImages } from "../utils/cacheImages";
 import {
   Ionicons,
   MaterialCommunityIcons,
@@ -19,6 +20,10 @@ export default function RootLayout() {
     MaterialCommunityIcons.loadFont();
     FontAwesome.loadFont();
     AntDesign.loadFont();
+    cacheImages([
+      require("../assets/images/backroundLogin.png"),
+      require("../assets/images/avatar.png"),
+    ]);
   }, []);
 
   return (

--- a/app/ctsp.jsx
+++ b/app/ctsp.jsx
@@ -6,6 +6,7 @@ import { ActivityIndicator, FlatList, Image, Modal, SafeAreaView, StyleSheet, Te
 
 import Toast from 'react-native-toast-message';
 import axiosInstance from '../utils/AxiosInstance';
+import { cacheImages } from '../utils/cacheImages';
 
 import BuyWithList from '../compomentCTSP/BuyWithList';
 import OptionGroup from '../compomentCTSP/OptionGroup';
@@ -95,6 +96,7 @@ const fetchAllProducts = async () => {
       sold: p.sold || 0,
     }));
     console.log('allProducts ›', list);
+    cacheImages(list.map((p) => p.image?.uri || p.image));
     return list;
   } catch {
     return [];
@@ -136,6 +138,10 @@ export default function CTSP() {
         if (!productId) throw new Error('Thiếu ID sản phẩm');
         const fetched = await fetchProductById(productId);
         setProduct(fetched);
+        cacheImages([
+          fetched.image?.uri || fetched.image,
+          ...((fetched.images || []).map((img) => img.uri || img)),
+        ]);
         // Lưu biến thể vào state
         setVariants(fetched.variants || []);
         setCompareProducts([fetched]);

--- a/utils/cacheImages.js
+++ b/utils/cacheImages.js
@@ -1,0 +1,17 @@
+import { Asset } from 'expo-asset';
+import { Image } from 'expo-image';
+
+/**
+ * Prefetch an array of images into the disk cache.
+ * Each item can be a local require() or a remote URL string.
+ * Returns a Promise that resolves when all images are cached.
+ */
+export async function cacheImages(images = []) {
+  const tasks = images.map((img) => {
+    if (typeof img === 'string') {
+      return Image.prefetch(img);
+    }
+    return Asset.loadAsync(img);
+  });
+  await Promise.all(tasks);
+}


### PR DESCRIPTION
## Summary
- prefetch product images on home and detail screens
- cache images when fetching all products

## Testing
- `npx -y expo lint` *(fails: Cannot find module 'eslint')*

------
https://chatgpt.com/codex/tasks/task_b_6883e85e53f0832c9dc53af5bff778fa