### PR TITLE
refactor: replace skeleton placeholder with moti

### DIFF
--- a/app/SkeletonBuildPC.jsx
+++ b/app/SkeletonBuildPC.jsx
@@ -1,30 +1,40 @@
 import { View, Dimensions } from "react-native";
-import SkeletonPlaceholder from "react-native-skeleton-placeholder";
+import { Skeleton } from "moti/skeleton";
 const { width } = Dimensions.get("window");
 
 export default function SkeletonBuildPC() {
   return (
-    <SkeletonPlaceholder borderRadius={10}>
-      <View style={{ padding: 20 }}>
-        {/* Header */}
-        <View style={{ width: width - 40, height: 40, borderRadius: 12, marginBottom: 18 }} />
-        {/* Progress bar */}
-        <View style={{ width: width - 40, height: 12, borderRadius: 6, marginBottom: 18 }} />
-        {/* Build type scroll */}
-        <View style={{ flexDirection: "row", marginBottom: 18 }}>
-          {[...Array(3)].map((_, i) => (
-            <View key={i} style={{ width: 120, height: 80, borderRadius: 16, marginRight: 12 }} />
-          ))}
-        </View>
-        {/* Price summary */}
-        <View style={{ width: width - 40, height: 36, borderRadius: 10, marginBottom: 18 }} />
-        {/* Category list */}
-        {[...Array(4)].map((_, i) => (
-          <View key={i} style={{ width: width - 40, height: 70, borderRadius: 14, marginBottom: 14 }} />
-        ))}
-        {/* Action button */}
-        <View style={{ width: width - 40, height: 48, borderRadius: 16, marginTop: 18 }} />
+    <View style={{ padding: 20 }}>
+      {/* Header */}
+      <View style={{ marginBottom: 18 }}>
+        <Skeleton width={width - 40} height={40} radius={12} />
       </View>
-    </SkeletonPlaceholder>
+      {/* Progress bar */}
+      <View style={{ marginBottom: 18 }}>
+        <Skeleton width={width - 40} height={12} radius={6} />
+      </View>
+      {/* Build type scroll */}
+      <View style={{ flexDirection: "row", marginBottom: 18 }}>
+        {[...Array(3)].map((_, i) => (
+          <View key={i} style={{ marginRight: 12 }}>
+            <Skeleton width={120} height={80} radius={16} />
+          </View>
+        ))}
+      </View>
+      {/* Price summary */}
+      <View style={{ marginBottom: 18 }}>
+        <Skeleton width={width - 40} height={36} radius={10} />
+      </View>
+      {/* Category list */}
+      {[...Array(4)].map((_, i) => (
+        <View key={i} style={{ marginBottom: 14 }}>
+          <Skeleton width={width - 40} height={70} radius={14} />
+        </View>
+      ))}
+      {/* Action button */}
+      <View style={{ marginTop: 18 }}>
+        <Skeleton width={width - 40} height={48} radius={16} />
+      </View>
+    </View>
   );
 }

--- a/app/SkeletonCTSP.jsx
+++ b/app/SkeletonCTSP.jsx
@@ -1,30 +1,46 @@
 import { View, Dimensions } from "react-native";
-import SkeletonPlaceholder from "react-native-skeleton-placeholder";
+import { Skeleton } from "moti/skeleton";
 const { width } = Dimensions.get("window");
 
 export default function SkeletonCTSP() {
   return (
-    <SkeletonPlaceholder borderRadius={10}>
-      <View style={{ padding: 16 }}>
-        {/* Header */}
-        <View style={{ width: width - 32, height: 36, borderRadius: 12, marginBottom: 18 }} />
-        {/* Ảnh sản phẩm */}
-        <View style={{ width: width - 32, height: 220, borderRadius: 18, marginBottom: 18 }} />
-        {/* Tên sản phẩm */}
-        <View style={{ width: width - 80, height: 28, borderRadius: 8, marginBottom: 10 }} />
-        {/* Meta */}
-        <View style={{ width: width - 120, height: 18, borderRadius: 8, marginBottom: 10 }} />
-        {/* Giá */}
-        <View style={{ width: 120, height: 28, borderRadius: 8, marginBottom: 18 }} />
-        {/* Option/variant */}
-        <View style={{ width: width - 32, height: 40, borderRadius: 10, marginBottom: 18 }} />
-        {/* Mô tả */}
-        <View style={{ width: width - 32, height: 60, borderRadius: 10, marginBottom: 18 }} />
-        {/* Specs */}
-        <View style={{ width: width - 32, height: 40, borderRadius: 10, marginBottom: 18 }} />
-        {/* Nút mua */}
-        <View style={{ width: width - 32, height: 48, borderRadius: 14, marginTop: 18 }} />
+    <View style={{ padding: 16 }}>
+      {/* Header */}
+      <View style={{ marginBottom: 18 }}>
+        <Skeleton width={width - 32} height={36} radius={12} />
       </View>
-    </SkeletonPlaceholder>
+      {/* Ảnh sản phẩm */}
+      <View style={{ marginBottom: 18 }}>
+        <Skeleton width={width - 32} height={220} radius={18} />
+      </View>
+      {/* Tên sản phẩm */}
+      <View style={{ marginBottom: 10 }}>
+        <Skeleton width={width - 80} height={28} radius={8} />
+      </View>
+      {/* Meta */}
+      <View style={{ marginBottom: 10 }}>
+        <Skeleton width={width - 120} height={18} radius={8} />
+      </View>
+      {/* Giá */}
+      <View style={{ marginBottom: 18 }}>
+        <Skeleton width={120} height={28} radius={8} />
+      </View>
+      {/* Option/variant */}
+      <View style={{ marginBottom: 18 }}>
+        <Skeleton width={width - 32} height={40} radius={10} />
+      </View>
+      {/* Mô tả */}
+      <View style={{ marginBottom: 18 }}>
+        <Skeleton width={width - 32} height={60} radius={10} />
+      </View>
+      {/* Specs */}
+      <View style={{ marginBottom: 18 }}>
+        <Skeleton width={width - 32} height={40} radius={10} />
+      </View>
+      {/* Nút mua */}
+      <View style={{ marginTop: 18 }}>
+        <Skeleton width={width - 32} height={48} radius={14} />
+      </View>
+    </View>
   );
 }

--- a/app/SkeletonCart.jsx
+++ b/app/SkeletonCart.jsx
@@ -1,24 +1,32 @@
 import { View, Dimensions } from "react-native";
-import SkeletonPlaceholder from "react-native-skeleton-placeholder";
+import { Skeleton } from "moti/skeleton";
 const { width } = Dimensions.get("window");
 
 export default function SkeletonCart() {
   return (
-    <SkeletonPlaceholder borderRadius={10}>
-      <View style={{ padding: 18 }}>
-        {/* Header */}
-        <View style={{ width: width - 36, height: 36, borderRadius: 12, marginBottom: 18 }} />
-        {/* Địa chỉ */}
-        <View style={{ width: width - 36, height: 40, borderRadius: 12, marginBottom: 18 }} />
-        {/* Danh sách sản phẩm */}
-        {[...Array(3)].map((_, i) => (
-          <View key={i} style={{ width: width - 36, height: 90, borderRadius: 14, marginBottom: 14 }} />
-        ))}
-        {/* Tổng tiền */}
-        <View style={{ width: width - 36, height: 48, borderRadius: 14, marginTop: 18 }} />
-        {/* Thanh toán */}
-        <View style={{ width: width - 36, height: 48, borderRadius: 14, marginTop: 14 }} />
+    <View style={{ padding: 18 }}>
+      {/* Header */}
+      <View style={{ marginBottom: 18 }}>
+        <Skeleton width={width - 36} height={36} radius={12} />
       </View>
-    </SkeletonPlaceholder>
+      {/* Địa chỉ */}
+      <View style={{ marginBottom: 18 }}>
+        <Skeleton width={width - 36} height={40} radius={12} />
+      </View>
+      {/* Danh sách sản phẩm */}
+      {[...Array(3)].map((_, i) => (
+        <View key={i} style={{ marginBottom: 14 }}>
+          <Skeleton width={width - 36} height={90} radius={14} />
+        </View>
+      ))}
+      {/* Tổng tiền */}
+      <View style={{ marginTop: 18 }}>
+        <Skeleton width={width - 36} height={48} radius={14} />
+      </View>
+      {/* Thanh toán */}
+      <View style={{ marginTop: 14 }}>
+        <Skeleton width={width - 36} height={48} radius={14} />
+      </View>
+    </View>
   );
 }

--- a/app/SkeletonHome.jsx
+++ b/app/SkeletonHome.jsx
@@ -1,32 +1,42 @@
 import { Dimensions, View } from "react-native";
-import SkeletonPlaceholder from "react-native-skeleton-placeholder";
+import { Skeleton } from "moti/skeleton";
 const { width } = Dimensions.get("window");
 
 export default function SkeletonHome() {
   return (
-    <SkeletonPlaceholder borderRadius={8}>
-      <View style={{ margin: 16 }}>
-        {/* Banner */}
-        <View style={{ width: width - 32, height: 120, borderRadius: 18, marginBottom: 18 }} />
-        {/* Danh mục */}
-        <View style={{ flexDirection: "row", marginBottom: 18 }}>
-          {[...Array(5)].map((_, i) => (
-            <View key={i} style={{ width: 60, height: 60, borderRadius: 30, marginRight: 12 }} />
-          ))}
-        </View>
-        {/* Flash sale */}
-        <View style={{ height: 28, width: 120, marginBottom: 10 }} />
-        <View style={{ flexDirection: "row", marginBottom: 18 }}>
-          {[...Array(3)].map((_, i) => (
-            <View key={i} style={{ width: 110, height: 150, borderRadius: 12, marginRight: 12 }} />
-          ))}
-        </View>
-        {/* Sản phẩm gợi ý */}
-        <View style={{ height: 28, width: 180, marginBottom: 10 }} />
-        {[...Array(4)].map((_, i) => (
-          <View key={i} style={{ width: width - 32, height: 90, borderRadius: 12, marginBottom: 14 }} />
+    <View style={{ margin: 16 }}>
+      {/* Banner */}
+      <View style={{ marginBottom: 18 }}>
+        <Skeleton width={width - 32} height={120} radius={18} />
+      </View>
+      {/* Danh mục */}
+      <View style={{ flexDirection: "row", marginBottom: 18 }}>
+        {[...Array(5)].map((_, i) => (
+          <View key={i} style={{ marginRight: 12 }}>
+            <Skeleton width={60} height={60} radius={30} />
+          </View>
         ))}
       </View>
-    </SkeletonPlaceholder>
+      {/* Flash sale */}
+      <View style={{ marginBottom: 10 }}>
+        <Skeleton width={120} height={28} />
+      </View>
+      <View style={{ flexDirection: "row", marginBottom: 18 }}>
+        {[...Array(3)].map((_, i) => (
+          <View key={i} style={{ marginRight: 12 }}>
+            <Skeleton width={110} height={150} radius={12} />
+          </View>
+        ))}
+      </View>
+      {/* Sản phẩm gợi ý */}
+      <View style={{ marginBottom: 10 }}>
+        <Skeleton width={180} height={28} />
+      </View>
+      {[...Array(4)].map((_, i) => (
+        <View key={i} style={{ marginBottom: 14 }}>
+          <Skeleton width={width - 32} height={90} radius={12} />
+        </View>
+      ))}
+    </View>
   );
 }

--- a/app/SkeletonLiveVideo.jsx
+++ b/app/SkeletonLiveVideo.jsx
@@ -1,18 +1,20 @@
 import { View, Dimensions } from "react-native";
-import SkeletonPlaceholder from "react-native-skeleton-placeholder";
+import { Skeleton } from "moti/skeleton";
 const { width, height } = Dimensions.get("window");
 
 export default function SkeletonLiveVideo() {
   return (
-    <SkeletonPlaceholder borderRadius={8}>
-      <View style={{ width, height, backgroundColor: "#222" }}>
-        {/* Video khung */}
-        <View style={{ width, height: height * 0.6 }} />
-        {/* Combo section */}
-        <View style={{ position: "absolute", bottom: 32, left: 16, width: width * 0.56, height: height / 3.2, borderRadius: 14 }} />
-        {/* User row */}
-        <View style={{ position: "absolute", bottom: height / 3, left: 16, width: 120, height: 32, borderRadius: 16 }} />
+    <View style={{ width, height, backgroundColor: "#222" }}>
+      {/* Video khung */}
+      <Skeleton width={width} height={height * 0.6} />
+      {/* Combo section */}
+      <View style={{ position: "absolute", bottom: 32, left: 16 }}>
+        <Skeleton width={width * 0.56} height={height / 3.2} radius={14} />
       </View>
-    </SkeletonPlaceholder>
+      {/* User row */}
+      <View style={{ position: "absolute", bottom: height / 3, left: 16 }}>
+        <Skeleton width={120} height={32} radius={16} />
+      </View>
+    </View>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "firebase": "^11.10.0",
         "lottie-ios": "^4.5.1",
         "lottie-react-native": "7.2.2",
+        "moti": "^0.30.0",
         "multer": "^2.0.1",
         "react": "19.0.0",
         "react-dom": "19.0.0",
@@ -63,7 +64,6 @@
         "react-native-render-html": "^6.3.4",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
-        "react-native-skeleton-placeholder": "^5.2.4",
         "react-native-tab-view": "^4.1.2",
         "react-native-toast-message": "^2.3.0",
         "react-native-vector-icons": "^10.2.0",
@@ -1508,6 +1508,23 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
@@ -3328,6 +3345,70 @@
         "@jsamr/counter-style": "^1.0.0 || ^2.0.0",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/@motionone/animation": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.18.0.tgz",
+      "integrity": "sha512-9z2p5GFGCm0gBsZbi8rVMOAJCtw1WqBTIPw3ozk06gDvZInBPIsQcHgYogEJ4yuHJ+akuW8g1SEIOpTOvYs8hw==",
+      "license": "MIT",
+      "dependencies": {
+        "@motionone/easing": "^10.18.0",
+        "@motionone/types": "^10.17.1",
+        "@motionone/utils": "^10.18.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/dom": {
+      "version": "10.12.0",
+      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.12.0.tgz",
+      "integrity": "sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==",
+      "license": "MIT",
+      "dependencies": {
+        "@motionone/animation": "^10.12.0",
+        "@motionone/generators": "^10.12.0",
+        "@motionone/types": "^10.12.0",
+        "@motionone/utils": "^10.12.0",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/easing": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.18.0.tgz",
+      "integrity": "sha512-VcjByo7XpdLS4o9T8t99JtgxkdMcNWD3yHU/n6CLEz3bkmKDRZyYQ/wmSf6daum8ZXqfUAgFeCZSpJZIMxaCzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@motionone/utils": "^10.18.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/generators": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.18.0.tgz",
+      "integrity": "sha512-+qfkC2DtkDj4tHPu+AFKVfR/C30O1vYdvsGYaR13W/1cczPrrcjdvYCj0VLFuRMN+lP1xvpNZHCRNM4fBzn1jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@motionone/types": "^10.17.1",
+        "@motionone/utils": "^10.18.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@motionone/types": {
+      "version": "10.17.1",
+      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.17.1.tgz",
+      "integrity": "sha512-KaC4kgiODDz8hswCrS0btrVrzyU2CSQKO7Ps90ibBVSQmjkrt2teqta6/sOG59v7+dPnKMAg13jyqtMKV2yJ7A==",
+      "license": "MIT"
+    },
+    "node_modules/@motionone/utils": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.18.0.tgz",
+      "integrity": "sha512-3XVF7sgyTSI2KWvTf6uLlBJ5iAgRgmvp3bpuOiQJvInd4nZ19ET8lX5unn30SlmRH7hXbBbH+Gxd0m0klJ3Xtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@motionone/types": "^10.17.1",
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -8165,6 +8246,36 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
+      "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@motionone/dom": "10.12.0",
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "popmotion": "11.0.3",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
+        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/framesync": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
+      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/freeport-async": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/freeport-async/-/freeport-async-2.0.0.tgz",
@@ -8569,6 +8680,12 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/hey-listen": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
+      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
+      "license": "MIT"
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -10555,6 +10672,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/moti": {
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/moti/-/moti-0.30.0.tgz",
+      "integrity": "sha512-YN78mcefo8kvJaL+TZNyusq6YA2aMFvBPl8WiLPy4eb4wqgOFggJOjP9bUr2YO8PrAt0uusmRG8K4RPL4OhCsA==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^6.5.1"
+      },
+      "peerDependencies": {
+        "react-native-reanimated": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -11247,6 +11376,18 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/popmotion": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
+      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
+      "license": "MIT",
+      "dependencies": {
+        "framesync": "6.0.1",
+        "hey-listen": "^1.0.8",
+        "style-value-types": "5.0.0",
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -11838,17 +11979,6 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/react-native-skeleton-placeholder": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/react-native-skeleton-placeholder/-/react-native-skeleton-placeholder-5.2.4.tgz",
-      "integrity": "sha512-OZntVq1hU1UX33FltxK2ezT2v9vHIhV8YnEbnMWUCvxT0N9OsgD1qxiHm6qb9YRJVgq2o5z3S7dNPsPnDF/jNg==",
-      "peerDependencies": {
-        "@react-native-masked-view/masked-view": "^0.2.8",
-        "react": ">=0.14.8",
-        "react-native": ">=0.50.1",
-        "react-native-linear-gradient": "^2.5.6"
       }
     },
     "node_modules/react-native-tab-view": {
@@ -13352,6 +13482,16 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-0.4.1.tgz",
       "integrity": "sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg=="
+    },
+    "node_modules/style-value-types": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
+      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
+      "license": "MIT",
+      "dependencies": {
+        "hey-listen": "^1.0.8",
+        "tslib": "^2.1.0"
+      }
     },
     "node_modules/styleq": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-native-render-html": "^6.3.4",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
-    "react-native-skeleton-placeholder": "^5.2.4",
+    "moti": "^0.30.0",
     "react-native-tab-view": "^4.1.2",
     "react-native-toast-message": "^2.3.0",
     "react-native-vector-icons": "^10.2.0",


### PR DESCRIPTION
## Summary
- replace `react-native-skeleton-placeholder` with `moti/skeleton`
- add `moti` dependency and drop unused `react-native-skeleton-placeholder`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: expo: not found)*

------
https://chatgpt.com/codex/tasks/task_b_688c5a8e1048832ca7d48dc6c4ac32b4

## Summary by Sourcery

Replace react-native-skeleton-placeholder with moti’s Skeleton component across all skeleton views and update dependencies accordingly

Enhancements:
- Swap out SkeletonPlaceholder for moti/skeleton in SkeletonCTSP, SkeletonHome, SkeletonBuildPC, SkeletonCart, and SkeletonLiveVideo components
- Adjust skeleton component layouts to use moti Skeleton props instead of container-based placeholders

Build:
- Remove react-native-skeleton-placeholder dependency and add moti to package.json