### PR TITLE
feat: add push notification registration

### DIFF
--- a/app.json
+++ b/app.json
@@ -54,7 +54,8 @@
           "displayName": "HiPC",
           "scheme": "fb1287087949733876"
         }
-      ]
+      ],
+      "expo-notifications"
     ],
     "experiments": {
       "typedRoutes": true

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -12,6 +12,8 @@ import {
   AntDesign,
 } from "@expo/vector-icons";
 import { StripeProvider } from "@stripe/stripe-react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { registerForPushNotificationsAsync } from "../utils/notifications";
 
 export default function RootLayout() {
   useEffect(() => {
@@ -19,6 +21,22 @@ export default function RootLayout() {
     MaterialCommunityIcons.loadFont();
     FontAwesome.loadFont();
     AntDesign.loadFont();
+  }, []);
+
+  useEffect(() => {
+    const setupPush = async () => {
+      try {
+        const stored = await AsyncStorage.getItem('user');
+        const user = stored ? JSON.parse(stored) : null;
+        const userId = user?._id || user?.id;
+        if (userId) {
+          await registerForPushNotificationsAsync(userId);
+        }
+      } catch (e) {
+        console.error('Failed to register push notifications', e);
+      }
+    };
+    setupPush();
   }, []);
 
   return (

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -1,0 +1,42 @@
+import * as Device from 'expo-device';
+import * as Notifications from 'expo-notifications';
+import * as Linking from 'expo-linking';
+import { Platform } from 'react-native';
+import axiosInstance from './AxiosInstance';
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowAlert: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+});
+
+export async function registerForPushNotificationsAsync(userId: string) {
+  if (!Device.isDevice) return null;
+
+  const { status: existingStatus } = await Notifications.getPermissionsAsync();
+  let finalStatus = existingStatus;
+  if (existingStatus !== 'granted') {
+    const { status } = await Notifications.requestPermissionsAsync();
+    finalStatus = status;
+  }
+  if (finalStatus !== 'granted') return null;
+
+  const token = (await Notifications.getExpoPushTokenAsync()).data;
+
+  await axiosInstance.post('/api/push/register-device', {
+    userId,
+    expoPushToken: token,
+    platform: Platform.OS,
+    appVersion: '1.0.0',
+    locale: 'vi-VN',
+  });
+
+  Notifications.addNotificationResponseReceivedListener(resp => {
+    const url = resp.notification.request.content.data?.url as string | undefined;
+    if (url) Linking.openURL(url);
+  });
+
+  return token;
+}


### PR DESCRIPTION
## Summary
- add Expo push notification helper and registration
- invoke push registration on app startup using AsyncStorage user ID
- enable expo-notifications plugin
- register device tokens using shared Axios instance

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 'addressText' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689f62549c008330b101ae6f906e13af

## Summary by Sourcery

Add Expo push notification support with automatic device registration and response handling

New Features:
- Introduce a notifications utility module to request permissions, generate Expo push tokens, and register devices via the backend
- Invoke automatic push registration on app startup using stored user ID in the root layout component
- Enable the expo-notifications plugin in the app configuration

Enhancements:
- Add a notification response listener to deep link to URLs when notifications are tapped