### PR TITLE
fix variant dialog and add-to-cart stock checks

### DIFF
--- a/app/chatboxai.jsx
+++ b/app/chatboxai.jsx
@@ -502,37 +502,45 @@ const [pendingAction, setPendingAction] = useState(''); // 'cart' | 'buy'
 
 const handleAddToCart = async (product) => {
   if (await mustLogin()) {
-    Toast.show({ type:'error', text1:'Vui lòng đăng nhập để mua hàng!', position:'top' });
+    Toast.show({ type: 'error', text1: 'Vui lòng đăng nhập để mua hàng!', position: 'top' });
     return router.push('/LoginScreen');
   }
-   // LUÔN mở dialog như FlashSale
- setSelectedProduct(product);
- setPendingAction('cart');
- setShowVariantDialog(true);
- const opts = extractVariantOptions(product);
- const first = (opts && opts.find(o => (o?.stock ?? 1) > 0)) || (opts && opts[0]) || null;
- setSelectedVariant(first);
- setVariantQuantity(1);
 
-  
-  
+  // Chỉ mở dialog nếu sản phẩm có biến thể
+  if (product?.variants && product.variants.length > 0) {
+    setSelectedProduct(product);
+    setPendingAction('cart');
+    setShowVariantDialog(true);
+    const opts = extractVariantOptions(product);
+    const first = (opts && opts.find(o => (o?.stock ?? 1) > 0)) || (opts && opts[0]) || null;
+    setSelectedVariant(first);
+    setVariantQuantity(1);
+    return;
+  }
+
+  Toast.show({ type: 'error', text1: 'Vui lòng chọn biến thể sản phẩm', position: 'top' });
 };
 
 const handleBuyNow = async (product) => {
   if (await mustLogin()) {
-    Toast.show({ type:'error', text1:'Vui lòng đăng nhập để mua hàng!', position:'top' });
+    Toast.show({ type: 'error', text1: 'Vui lòng đăng nhập để mua hàng!', position: 'top' });
     return router.push('/LoginScreen');
   }
 
-   // LUÔN mở dialog như FlashSale
- setSelectedProduct(product);
- setPendingAction('buy');
- setShowVariantDialog(true);
- const opts = extractVariantOptions(product);
- const first = (opts && opts.find(o => (o?.stock ?? 1) > 0)) || (opts && opts[0]) || null;
- setSelectedVariant(first);
- setVariantQuantity(1);
-  };
+  // Chỉ mở dialog nếu sản phẩm có biến thể
+  if (product?.variants && product.variants.length > 0) {
+    setSelectedProduct(product);
+    setPendingAction('buy');
+    setShowVariantDialog(true);
+    const opts = extractVariantOptions(product);
+    const first = (opts && opts.find(o => (o?.stock ?? 1) > 0)) || (opts && opts[0]) || null;
+    setSelectedVariant(first);
+    setVariantQuantity(1);
+    return;
+  }
+
+  Toast.show({ type: 'error', text1: 'Vui lòng chọn biến thể sản phẩm', position: 'top' });
+};
 
 
 const handleVariantSelect = (variant) => {
@@ -551,6 +559,13 @@ const handleConfirmVariant = async () => {
     return Toast.show({ type:'error', text1:'Vui lòng chọn biến thể sản phẩm', position:'top' });
   }
 
+  // Kiểm tra tồn kho
+  const stock = Number(selectedVariant?.stock ?? 0);
+  if (variantQuantity > stock) {
+    setVariantQuantity(stock);
+    return Toast.show({ type: 'error', text1: `Chỉ còn ${stock} sản phẩm`, position: 'top' });
+  }
+
   try {
     if (pendingAction === 'buy') {
       const priceShown = getDisplayPrice(selectedProduct, selectedVariant);
@@ -561,7 +576,7 @@ const handleConfirmVariant = async () => {
           ? selectedProduct.image
           : selectedProduct.image?.uri || selectedProduct.image,
         quantity: variantQuantity,
-        price: priceShown, // base/price + priceDiff (nếu có)
+        price: priceShown,
         variant: {
           _id: getVariantId(selectedVariant),
           key: selectedProduct?.variants?.[0]?.key || 'Phiên bản',

--- a/compomentHome/ForYouGrid.jsx
+++ b/compomentHome/ForYouGrid.jsx
@@ -74,6 +74,7 @@ export default function ForYouGrid({
       }
     });
     setVariantSelections(defaults);
+    setSelectedOption(Object.values(defaults)[0] || null);
     setQuantity(1);
     setShowOptionDialog(true);
     return;
@@ -107,25 +108,14 @@ export default function ForYouGrid({
       }
     }
 
-    let variantPayload;
-    if (groups.length === 1) {
-      const group = groups[0];
-      const selected = variantSelections[group.key];
-      variantPayload = {
-        key: group.key,
-        label: selected.label,
-        priceDiff: selected.priceDiff || 0
-      };
-    } else {
-      const keys = Object.keys(variantSelections);
-      const labels = keys.map(k => variantSelections[k]?.label).filter(Boolean);
-      const priceDiffSum = keys.reduce((sum, k) => sum + (variantSelections[k]?.priceDiff || 0), 0);
-
-      variantPayload = {
-        key: keys.join(' + '),
-        label: labels.join(' + '),
-        priceDiff: priceDiffSum
-      };
+    // Lấy option được chọn của nhóm đầu tiên (giống FlashSale)
+    const firstGroup = groups[0];
+    const selectedOpt = variantSelections[firstGroup.key];
+    const variantId = selectedOpt?._id || selectedOpt?.id;
+    const stock = Number(selectedOpt?.stock ?? 0);
+    if (quantity > stock) {
+      setQuantity(stock);
+      return Toast.show({ type: 'error', text1: `Chỉ còn ${stock} sản phẩm` });
     }
 
     if (!isLoggedIn) return onRequireLogin();
@@ -141,8 +131,8 @@ export default function ForYouGrid({
       await axiosInstance.post('/cartt/add-to-cart', {
         user_id: userId,
         productId: selectedProduct.id || selectedProduct._id,
-        quantity,
-        variant: variantPayload
+        variantId,
+        quantity
       });
       setShowOptionDialog(false);
       Toast.show({ type: 'success', text1: 'Đã thêm vào giỏ hàng!', position: 'bottom' });
@@ -413,7 +403,11 @@ export default function ForYouGrid({
                   {selectedProduct.variants[0]?.options?.map((option, idx) => (
                     <TouchableOpacity
                       key={idx}
-                      onPress={() => setSelectedOption(option)}
+                      onPress={() => {
+                        const key = selectedProduct.variants[0]?.key;
+                        setSelectedOption(option);
+                        if (key) setVariantSelections(prev => ({ ...prev, [key]: option }));
+                      }}
                       style={[
                         styles.optionButton,
                         selectedOption === option && styles.optionButtonSelected
@@ -500,12 +494,18 @@ export default function ForYouGrid({
                     value={quantity.toString()}
                     onChangeText={txt => {
                       const val = parseInt(txt.replace(/[^0-9]/g, '')) || 1;
-                      setQuantity(val);
+                      const key = selectedProduct.variants[0]?.key;
+                      const max = Number(variantSelections[key]?.stock ?? 99);
+                      setQuantity(Math.min(val, max));
                     }}
                     textAlign="center"
                   />
                   <TouchableOpacity
-                    onPress={() => setQuantity(q => q + 1)}
+                    onPress={() => {
+                      const key = selectedProduct.variants[0]?.key;
+                      const max = Number(variantSelections[key]?.stock ?? 99);
+                      setQuantity(q => Math.min(max, q + 1));
+                    }}
                     style={styles.quantityButton}
                   >
                     <Ionicons name="add" size={20} color="#667eea" />

--- a/compomentHome/NewProducts.jsx
+++ b/compomentHome/NewProducts.jsx
@@ -73,7 +73,7 @@ export default function NewProducts({
   const handleAddToCart = async (product) => {
   if (product.variants && product.variants.length > 0) {
     setSelectedProduct(product);
-    // Khởi tạo lựa chọn mặc định cho từng nhóm
+    // Khởi tạo lựa chọn mặc định
     const defaults = {};
     product.variants.forEach(group => {
       if (group.options && group.options.length > 0) {
@@ -81,6 +81,7 @@ export default function NewProducts({
       }
     });
     setVariantSelections(defaults);
+    setSelectedOption(Object.values(defaults)[0] || null);
     setQuantity(1);
     setShowOptionDialog(true);
     return;
@@ -116,25 +117,14 @@ export default function NewProducts({
       }
     }
 
-    let variantPayload;
-    if (groups.length === 1) {
-      const group = groups[0];
-      const selected = variantSelections[group.key];
-      variantPayload = {
-        key: group.key,
-        label: selected.label,
-        priceDiff: selected.priceDiff || 0
-      };
-    } else {
-      const keys = Object.keys(variantSelections);
-      const labels = keys.map(k => variantSelections[k]?.label).filter(Boolean);
-      const priceDiffSum = keys.reduce((sum, k) => sum + (variantSelections[k]?.priceDiff || 0), 0);
-
-      variantPayload = {
-        key: keys.join(' + '),
-        label: labels.join(' + '),
-        priceDiff: priceDiffSum
-      };
+    // Lấy option được chọn của nhóm đầu tiên
+    const firstGroup = groups[0];
+    const selectedOpt = variantSelections[firstGroup.key];
+    const variantId = selectedOpt?._id || selectedOpt?.id;
+    const stock = Number(selectedOpt?.stock ?? 0);
+    if (quantity > stock) {
+      setQuantity(stock);
+      return Toast.show({ type: 'error', text1: `Chỉ còn ${stock} sản phẩm` });
     }
 
     if (!isLoggedIn) return onRequireLogin();
@@ -150,8 +140,8 @@ export default function NewProducts({
       await axiosInstance.post('/cartt/add-to-cart', {
         user_id: userId,
         productId: selectedProduct.id || selectedProduct._id,
-        quantity,
-        variant: variantPayload
+        variantId,
+        quantity
       });
       setShowOptionDialog(false);
       Toast.show({ type: 'success', text1: 'Đã thêm vào giỏ hàng!', position: 'bottom' });
@@ -383,7 +373,11 @@ export default function NewProducts({
                   {selectedProduct.variants[0]?.options?.map((option, idx) => (
                     <TouchableOpacity
                       key={idx}
-                      onPress={() => setSelectedOption(option)}
+                      onPress={() => {
+                        const key = selectedProduct.variants[0]?.key;
+                        setSelectedOption(option);
+                        if (key) setVariantSelections(prev => ({ ...prev, [key]: option }));
+                      }}
                       style={[
                         styles.optionButton,
                         selectedOption === option && styles.optionButtonSelected
@@ -470,12 +464,18 @@ export default function NewProducts({
                     value={quantity.toString()}
                     onChangeText={txt => {
                       const val = parseInt(txt.replace(/[^0-9]/g, '')) || 1;
-                      setQuantity(val);
+                      const key = selectedProduct.variants[0]?.key;
+                      const max = Number(variantSelections[key]?.stock ?? 99);
+                      setQuantity(Math.min(val, max));
                     }}
                     textAlign="center"
                   />
                   <TouchableOpacity
-                    onPress={() => setQuantity(q => q + 1)}
+                    onPress={() => {
+                      const key = selectedProduct.variants[0]?.key;
+                      const max = Number(variantSelections[key]?.stock ?? 99);
+                      setQuantity(q => Math.min(max, q + 1));
+                    }}
                     style={styles.quantityButton}
                   >
                     <Ionicons name="add" size={20} color="#667eea" />


### PR DESCRIPTION
## Summary
- ensure chatbot AI only opens variant dialog for products with variants and blocks quantity beyond stock
- align ForYouGrid and NewProducts add-to-cart flows with FlashSale by selecting default variant, validating stock, and sending variantId

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: View is not defined, Ionicons is not defined, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68abd7885ed88330bbe8d1c58711ddd9